### PR TITLE
fix imports for local execution without deps/local install

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ def main(inputs_json: str, batch_size: int):
     inputs: JSON file describing input protein-ligand pairs (see diffdock.prepare)
     batch_size: number of protein-ligand pairs to submit for each job
     """
-    from diffdock import prepare
+    import prepare
     inputs = json.loads(Path(inputs_json).read_text())
     batched = prepare.batch_inputs(inputs, batch_size)
     model = Model()

--- a/prepare.py
+++ b/prepare.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+import itertools
+import os
+import json
+from io import BytesIO
+from zipfile import ZipFile
+from urllib.request import urlopen
+
+
+def input_json(
+    source_root_path: str,
+    dest_rel_path: str,
+    out_file: str,
+    protein_suffix: str = "_protein_processed.pdb",
+    ligand_suffix: str = "_ligand.pdb",
+):
+    """
+    source_root_path: a path to a directory containing subdirectories, each containing
+    exactly one file ending in `protein_suffix` and one or more files ending in
+    `ligand_suffix`.  For such a subdirectory, one JSON array entry is created for
+    each protein-ligand pair.
+
+    dest_rel_path: relative path
+    """
+    output = []
+    for dirpath, dirnames, filenames in os.walk(source_root_path):
+        protein_files = [f for f in filenames if f.endswith(protein_suffix)]
+        ligand_files = [f for f in filenames if f.endswith(ligand_suffix)]
+        tag = Path(dirpath).name
+        for i, (p, l) in enumerate(itertools.product(protein_files, ligand_files)):
+            entry = {
+                "complex_name": f"{tag}_{i}",
+                "protein_path": str(Path(dest_rel_path) / tag / p),
+                "ligand_description": str(Path(dest_rel_path) / tag / l),
+            }
+            output.append(entry)
+    out_str = json.dumps(output, indent=2)
+    Path(out_file).write_text(out_str)
+
+
+REPOSITORY_URL = os.environ.get("REPOSITORY_URL", "https://github.com/gcorso/DiffDock")
+REMOTE_URLS = [
+    f"{REPOSITORY_URL}/releases/latest/download/diffdock_models.zip",
+    f"{REPOSITORY_URL}/releases/download/v1.1/diffdock_models.zip",
+]
+
+
+def download_models(model_dir: str):
+    if not os.path.exists(model_dir):
+        os.makedirs(model_dir, exist_ok=True)
+
+    remote_urls = REMOTE_URLS
+    success = False
+    for remote_url in remote_urls:
+        try:
+            print(f"Attempting download from {remote_url}")
+            resp = urlopen(remote_url)
+            with ZipFile(BytesIO(resp.read())) as zip_file:
+                files_downloaded = zip_file.namelist()
+                zip_file.extractall(model_dir)
+            print(f"Extracted {len(files_downloaded)} files to {model_dir}")
+            success = True
+            break
+        except Exception as e:
+            pass
+
+    if not success:
+        raise RuntimeError(
+            f"Models not found locally and failed to download them from {remote_urls}"
+        )
+
+
+def build_caches(cache_dir: str):
+    from diffdock.utils import so3, torus
+
+    print(f"Building SO3 cache (this may take ~10 minutes) ...")
+    so3.build_cache(cache_dir)
+    print(f"Building SO(2)/torus cache (this may take awhile) ...")
+    torus.build_cache(cache_dir)
+    print(f"Wrote caches to {cache_dir}")
+
+
+def load_caches(cache_dir: str):
+    from diffdock.utils import so3, torus
+
+    so3.load_cache(cache_dir)
+    torus.load_cache(cache_dir)
+
+
+def batch_inputs(inputs: list, batch_size: int):
+    """
+    inputs: List of dicts of
+    """
+    inputs = [
+        tuple(inputs[i : i + batch_size]) for i in range(0, len(inputs), batch_size)
+    ]
+    batched = []
+    for group in inputs:
+        entry = {k + "s": [] for k in group[0].keys()}
+        for ent in group:
+            for k, v in ent.items():
+                entry[k + "s"].append(v)
+        batched.append(entry)
+    return batched
+
+
+if __name__ == "__main__":
+    import fire
+
+    cmds = dict(make_input=input_json, download=download_models)
+    fire.Fire(cmds)


### PR DESCRIPTION
This PR moves the `prepare.py` file into root and puts its import of `fire` under the "is main" check so that it can be run with just a `modal` install.

In @hrbigelow's environment, the diffdock package is installed locally, which leads to two issues with the current repo when you try to run it:
- The `prepare` module can't be imported `from diffdock` in the local environment
- The `fire` package is installed locally, so it can be imported locally when `prepare` is imported

The requirement to be runnable with no deps but `modal` was added last-minute, as was a repo reorg to move the diffdock code out of root.